### PR TITLE
Async dump

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,9 @@ This document describes changes between each past release.
 2.2.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+**New features**
+
+- Use ``asyncio`` to add parallelism to the ``load`` command (#18).
 
 
 2.1.0 (2017-06-28)

--- a/kinto_wizard/async_kinto.py
+++ b/kinto_wizard/async_kinto.py
@@ -1,0 +1,41 @@
+"""
+A poor man's asynchronous Kinto client.
+
+This is a hack to allow kinto_wizard functionality to call synchronous
+kinto-http methods asynchronously without having to keep track of an
+event loop and executor.
+
+"""
+
+import functools
+
+
+class AsyncKintoClient(object):
+    def __init__(self, client, loop, executor):
+        self.client = client
+        self.loop = loop
+        self.executor = executor
+
+    def batch(self):
+        # Don't do anything clever with asynchrony here -- just call
+        # the underlying batch() for now
+        return self.client.batch()
+
+    def __getattr__(self, attr_name):
+        return AsyncKintoMethod(self, attr_name)
+
+
+class AsyncKintoMethod(object):
+    def __init__(self, async_client, method_name):
+        self.async_client = async_client
+        self.method_name = method_name
+
+    def __call__(self, *args, **kwargs):
+        client = self.async_client.client
+        real_method = getattr(client, self.method_name)
+        executor = self.async_client.executor
+        loop = self.async_client.loop
+        return loop.run_in_executor(
+            executor,
+            functools.partial(real_method, *args, **kwargs)
+        )

--- a/kinto_wizard/kinto2yaml.py
+++ b/kinto_wizard/kinto2yaml.py
@@ -6,26 +6,26 @@ def _sorted_principals(permissions):
     return {perm: sorted(principals) for perm, principals in permissions.items()}
 
 
-def introspect_server(client, bucket=None, collection=None, full=False):
+async def introspect_server(client, bucket=None, collection=None, full=False):
     if bucket:
         logger.info("Only inspect bucket `{}`.".format(bucket))
-        bucket_info = introspect_bucket(client, bucket, collection=collection, full=full)
+        bucket_info = await introspect_bucket(client, bucket, collection=collection, full=full)
         if bucket_info:
             return {bucket: bucket_info}
         return {}
 
     logger.info("Fetch buckets list.")
-    buckets = client.get_buckets()
+    buckets = await client.get_buckets()
     return {
-        bucket['id']: introspect_bucket(client, bucket['id'], collection=collection, full=full)
+        bucket['id']: await introspect_bucket(client, bucket['id'], collection=collection, full=full)
         for bucket in buckets
     }
 
 
-def introspect_bucket(client, bid, collection=None, full=False):
+async def introspect_bucket(client, bid, collection=None, full=False):
     logger.info("Fetch information of bucket {!r}".format(bid))
     try:
-        bucket = client.get_bucket(id=bid)
+        bucket = await client.get_bucket(id=bid)
     except kinto_exceptions.BucketNotFound:
         logger.error("Could not read bucket {!r}".format(bid))
         return None
@@ -37,19 +37,19 @@ def introspect_bucket(client, bid, collection=None, full=False):
     if collection:
         result = {
             'permissions': _sorted_principals(permissions),
-            'collections': {collection: introspect_collection(client, bid, collection, full=full)}
+            'collections': {collection: await introspect_collection(client, bid, collection, full=full)}
         }
     else:
-        collections = client.get_collections(bucket=bid)
-        groups = client.get_groups(bucket=bid)
+        collections = await client.get_collections(bucket=bid)
+        groups = await client.get_groups(bucket=bid)
         result = {
             'permissions': _sorted_principals(permissions),
             'collections': {
-                collection['id']: introspect_collection(client, bid, collection['id'], full=full)
+                collection['id']: await introspect_collection(client, bid, collection['id'], full=full)
                 for collection in collections
             },
             'groups': {
-                group['id']: introspect_group(client, bid, group['id'], full=full)
+                group['id']: await introspect_group(client, bid, group['id'], full=full)
                 for group in groups
             }
         }
@@ -58,9 +58,9 @@ def introspect_bucket(client, bid, collection=None, full=False):
     return result
 
 
-def introspect_collection(client, bid, cid, full=False):
+async def introspect_collection(client, bid, cid, full=False):
     logger.info("Fetch information of collection {!r}/{!r}".format(bid, cid))
-    collection = client.get_collection(bucket=bid, id=cid)
+    collection = await client.get_collection(bucket=bid, id=cid)
     result = {
         'permissions': _sorted_principals(collection['permissions']),
     }
@@ -68,7 +68,7 @@ def introspect_collection(client, bid, cid, full=False):
         result['data'] = collection['data']
 
         # If full, include records.
-        records = client.get_records(bucket=bid, collection=cid)
+        records = await client.get_records(bucket=bid, collection=cid)
         result['records'] = {
             # XXX: we don't show permissions, until we have a way to fetch records
             # in batch (see Kinto/kinto-http.py#145)
@@ -77,9 +77,9 @@ def introspect_collection(client, bid, cid, full=False):
     return result
 
 
-def introspect_group(client, bid, gid, full=False):
+async def introspect_group(client, bid, gid, full=False):
     logger.info("Fetch information of group {!r}/{!r}".format(bid, gid))
-    group = client.get_group(bucket=bid, id=gid)
+    group = await client.get_group(bucket=bid, id=gid)
     result = {
         'permissions': _sorted_principals(group['permissions'])
     }

--- a/kinto_wizard/yaml2kinto.py
+++ b/kinto_wizard/yaml2kinto.py
@@ -9,7 +9,11 @@ async def initialize_server(async_client, config, bucket=None, collection=None, 
     cid = collection
     # 1. Introspect current server state.
     if not force:
-        current_server_status = await introspect_server(async_client, bucket=bucket, collection=collection)
+        current_server_status = await introspect_server(
+            async_client,
+            bucket=bucket,
+            collection=collection
+        )
     else:
         # We don't need to load it because we will override it nevertheless.
         current_server_status = {}

--- a/kinto_wizard/yaml2kinto.py
+++ b/kinto_wizard/yaml2kinto.py
@@ -3,18 +3,18 @@ from .logger import logger
 from .kinto2yaml import introspect_server
 
 
-def initialize_server(client, config, bucket=None, collection=None, force=False):
+async def initialize_server(async_client, config, bucket=None, collection=None, force=False):
     logger.debug("Converting YAML config into a server batch.")
     bid = bucket
     cid = collection
     # 1. Introspect current server state.
     if not force:
-        current_server_status = introspect_server(client, bucket=bucket, collection=collection)
+        current_server_status = await introspect_server(async_client, bucket=bucket, collection=collection)
     else:
         # We don't need to load it because we will override it nevertheless.
         current_server_status = {}
     # 2. For each bucket
-    with client.batch() as batch:
+    with async_client.batch() as batch:
         for bucket_id, bucket in config.items():
             # Skip buckets that we don't want to import.
             if bid and bucket_id != bid:


### PR DESCRIPTION
This tries to address the important parts of #18 by converting the `dump` command to use asyncio. The `load` command already writes in batches, and unwinding that would require lots more work, and for negligible benefit since the batches are already providing a certain asynchrony and parallelism.

It's still possible to add a tiny bit more parallelism to `introspect_collection`, but since there are only two requests, it seems like it would also be of negligible value.