### PR TITLE
Handle Yaml date and datetime values.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ This document describes changes between each past release.
 2.5.0 (unreleased)
 ------------------
 
+**Bug fixes**
+
+- Handle YAML date and datetime values. (#51)
+
 **Internal changes**
 
 - Add test for YAML node anchors support (#52)

--- a/kinto_wizard/kinto2yaml.py
+++ b/kinto_wizard/kinto2yaml.py
@@ -20,7 +20,8 @@ async def gather_dict(dct):
     """
     items = dct.items()
     results = await asyncio.gather(*(item[1] for item in items))
-    return {k: v for k, v in zip((item[0] for item in items), results) if v is not None}
+    keys_results = zip((item[0] for item in items), results)
+    return {k: v for k, v in keys_results if v is not None}
 
 
 async def introspect_server(client, bucket=None, collection=None, data=False, records=False):

--- a/kinto_wizard/yaml2kinto.py
+++ b/kinto_wizard/yaml2kinto.py
@@ -26,12 +26,16 @@ async def initialize_server(async_client, config, bucket=None, collection=None,
             if bid and bucket_id != bid:
                 logger.debug("Skip bucket {}".format(bucket_id))
                 continue
-
             bucket_exists = bucket_id in current_server_status
             bucket_data = bucket.get('data', {})
             bucket_permissions = bucket.get('permissions', {})
             bucket_groups = bucket.get('groups', {})
             bucket_collections = bucket.get('collections', {})
+
+            # Skip bucket if we don't have a collection in them
+            if cid and cid not in bucket_collections:
+                logger.debug("Skip bucket {}".format(bucket_id))
+                continue
 
             if not bucket_exists:
                 bucket_current_groups = {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
-certifi==2017.7.27.1
+certifi==2018.8.24
 chardet==3.0.4
-idna==2.6
-kinto-http==9.0.1
-requests==2.18.4
-ruamel.yaml==0.15.34
-six==1.11.0
-Unidecode==0.4.21
-urllib3==1.22
+idna==2.7
+kinto-http==10.0.0
+requests==2.19.1
+ruamel.yaml==0.15.72
+Unidecode==1.0.22
+urllib3==1.23

--- a/tests/dumps/dump-date.yaml
+++ b/tests/dumps/dump-date.yaml
@@ -1,0 +1,19 @@
+date:
+  collections:
+    dates:
+      data:
+        created_at: '2018-06-22T16:34:43.330907'
+        id: dates
+        last_modified: 1496132464691
+        published_date: '2018-06-22'
+      permissions:
+        write:
+        - basicauth:8e79ddf13abb4e8034f060b6f2975275975e5866727595301e77ba5494b127c4
+      records: {}
+  data:
+    id: date
+    last_modified: 1529681414530
+  groups: {}
+  permissions:
+    write:
+    - basicauth:8e79ddf13abb4e8034f060b6f2975275975e5866727595301e77ba5494b127c4

--- a/tests/dumps/dump-full.yaml
+++ b/tests/dumps/dump-full.yaml
@@ -50,3 +50,18 @@ natim2:
   permissions:
     write:
     - basicauth:8e79ddf13abb4e8034f060b6f2975275975e5866727595301e77ba5494b127c4
+date:
+  collections:
+    dates:
+      data:
+        id: toto
+        last_modified: 1496132464691
+        published_date: 2018-06-22
+        created_at: 2018-06-22 16:34:43.330907
+      permissions:
+        write:
+        - basicauth:8e79ddf13abb4e8034f060b6f2975275975e5866727595301e77ba5494b127c4
+  groups: {}
+  permissions:
+    write:
+    - basicauth:8e79ddf13abb4e8034f060b6f2975275975e5866727595301e77ba5494b127c4

--- a/tests/dumps/dump-full.yaml
+++ b/tests/dumps/dump-full.yaml
@@ -54,13 +54,17 @@ date:
   collections:
     dates:
       data:
-        id: toto
+        id: dates
         last_modified: 1496132464691
         published_date: 2018-06-22
         created_at: 2018-06-22 16:34:43.330907
       permissions:
         write:
         - basicauth:8e79ddf13abb4e8034f060b6f2975275975e5866727595301e77ba5494b127c4
+      records: {}
+  data:
+    id: date
+    last_modified: 1529681414530
   groups: {}
   permissions:
     write:

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -298,6 +298,12 @@ class BucketCollectionSelectionableDump(unittest.TestCase):
         with open("tests/dumps/dump-toto.yaml") as f:
             assert f.read() == generated
 
+    def test_wizard_can_handle_dates(self):
+        self.load(bucket="date")
+        generated = self.dump()
+        with open("tests/dumps/dump-date.yaml") as f:
+            assert f.read() == generated
+
 
 class YAMLReferenceSupportTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
We might have to handle that at the kinto-http level.

```
kinto_wizard/yaml2kinto.py:166: in initialize_server
    logger.debug('Sending batch:\n\n%s' % batch.session.requests)
/usr/lib/python3.6/contextlib.py:88: in __exit__
    next(self.gen)
.tox/py36/lib/python3.6/site-packages/kinto_http/__init__.py:105: in batch
    batch_session.send()
.tox/py36/lib/python3.6/site-packages/kinto_http/batch.py:61: in send
    resp, headers = self.session.request(**kwargs)
.tox/py36/lib/python3.6/site-packages/kinto_http/session.py:94: in request
    resp = requests.request(method, actual_url, **kwargs)
.tox/py36/lib/python3.6/site-packages/requests/api.py:58: in request
    return session.request(method=method, url=url, **kwargs)
.tox/py36/lib/python3.6/site-packages/requests/sessions.py:498: in request
    prep = self.prepare_request(req)
.tox/py36/lib/python3.6/site-packages/requests/sessions.py:441: in prepare_request
    hooks=merge_hooks(request.hooks, self.hooks),
.tox/py36/lib/python3.6/site-packages/requests/models.py:312: in prepare
    self.prepare_body(data, files, json)
.tox/py36/lib/python3.6/site-packages/requests/models.py:462: in prepare_body
    body = complexjson.dumps(json)
.tox/py36/lib/python3.6/site-packages/simplejson/__init__.py:382: in dumps
    return _default_encoder.encode(obj)
.tox/py36/lib/python3.6/site-packages/simplejson/encoder.py:296: in encode
    chunks = self.iterencode(o, _one_shot=True)
.tox/py36/lib/python3.6/site-packages/simplejson/encoder.py:378: in iterencode
    return _iterencode(o, 0)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <simplejson.encoder.JSONEncoder object at 0x7fc9530032e8>, o = datetime.date(2018, 6, 22)

    def default(self, o):
        """Implement this method in a subclass such that it returns
            a serializable object for ``o``, or calls the base implementation
            (to raise a ``TypeError``).
    
            For example, to support arbitrary iterators, you could
            implement default like this::
    
                def default(self, o):
                    try:
                        iterable = iter(o)
                    except TypeError:
                        pass
                    else:
                        return list(iterable)
                    return JSONEncoder.default(self, o)
    
            """
        raise TypeError('Object of type %s is not JSON serializable' %
>                       o.__class__.__name__)
E       TypeError: Object of type date is not JSON serializable

.tox/py36/lib/python3.6/site-packages/simplejson/encoder.py:273: TypeError
```