### PR TITLE
Fix mozilla/remote-settings#1009: add more options to dump/load only certain objects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,13 @@ Load
 
 The load command also accepts these options:
 
+* ``--data`` - Load data attributes.
+* ``--permissions``: - Load objects permissions.
+* ``--collections`` - Load collections.
+* ``--groups`` - Load groups.
+* ``--records`` - Load collections` records.
 * ``--attachments`` - Load the attachments files from the specified folder
+* ``--full`` - Combination of all flags (default).
 
 Dump
 ~~~~
@@ -59,7 +65,7 @@ The dump command also accepts these options:
 * ``--groups`` - Include groups.
 * ``--records`` - Include collections` records.
 * ``--attachments`` - Save the attachments files into the specified folder
-* ``--full`` - Combination of data and records.
+* ``--full`` - Combination of all flags (default).
 
 Validate a dump
 ---------------

--- a/README.rst
+++ b/README.rst
@@ -54,6 +54,9 @@ Dump
 The dump command also accepts these options:
 
 * ``--data`` - Include buckets, collections and groups data (attachments, schemas, display fields, uischema etc.).
+* ``--permissions``: - Include objects permissions.
+* ``--collections`` - Include collections.
+* ``--groups`` - Include groups.
 * ``--records`` - Include collections` records.
 * ``--attachments`` - Save the attachments files into the specified folder
 * ``--full`` - Combination of data and records.

--- a/src/kinto_wizard/__main__.py
+++ b/src/kinto_wizard/__main__.py
@@ -50,13 +50,29 @@ async def execute():
     cli_utils.add_parser_options(subparser)
     subparser.add_argument(
         "--full",
-        help="Full output (same as with both --data and --records options)",
+        help="Full output (same as with --data, --permissions, --collections, --groups and --records options)",
         action="store_true",
     )
+    for resource in ("collection", "group", "record"):
+        subparser.add_argument(
+            f"--{resource}s",
+            help=f"Export {resource}s",
+            action="store_true",
+            dest=f"dump_{resource}s",
+            default=None,
+        )
     subparser.add_argument(
-        "--data", help="Export buckets, collections and groups data", action="store_true"
+        "--data",
+        help="Export buckets, collections and groups data",
+        action="store_true",
+        default=False,
     )
-    subparser.add_argument("--records", help="Export collections' records", action="store_true")
+    subparser.add_argument(
+        "--permissions",
+        help="Export buckets, collections and groups permissions",
+        action="store_true",
+        default=False,
+    )
     subparser.add_argument(
         "--attachments", help="Export collections' attachments to specified folder", default=None
     )
@@ -100,13 +116,19 @@ async def execute():
     # Run chosen subcommand.
     if args.which == "dump":
         if args.full:
-            data = True
             records = True
+            collections = True
+            groups = True
             attachments = args.attachments or "__attachments__"
+            data = True
+            permissions = True
         else:
-            data = args.data
-            records = args.records
+            records = args.dump_records
+            collections = True  # args.dump_collections or args.dump_records
+            groups = True  # args.dump_groups
             attachments = args.attachments
+            data = args.data
+            permissions = args.permissions
 
         logger.debug(
             "Start introspection with %s...",
@@ -115,6 +137,9 @@ async def execute():
                     None,
                     [
                         "data" if data else None,
+                        "permissions" if permissions else None,
+                        "collections" if collections else None,
+                        "groups" if groups else None,
                         "records" if records else None,
                         "attachments" if attachments else None,
                     ],
@@ -127,6 +152,9 @@ async def execute():
             bucket=args.bucket,
             collection=args.collection,
             data=data,
+            permissions=permissions,
+            collections=collections,
+            groups=groups,
             records=records,
             attachments=attachments,
         )

--- a/src/kinto_wizard/__main__.py
+++ b/src/kinto_wizard/__main__.py
@@ -43,6 +43,34 @@ async def execute():
     subparser.add_argument(
         "--attachments", help="Load attachments from specified folder", default=None
     )
+    subparser.add_argument(
+        "--full",
+        help="Load everything (same as with all --load-... options)",
+        action="store_true",
+        default=None,
+    )
+    for resource in ("bucket", "collection", "group", "record"):
+        subparser.add_argument(
+            f"--{resource}s",
+            help=f"Load {resource}s",
+            action="store_true",
+            dest=f"load_{resource}s",
+            default=None,
+        )
+    subparser.add_argument(
+        "--data",
+        help="Load attributes",
+        action="store_true",
+        dest="load_data",
+        default=None,
+    )
+    subparser.add_argument(
+        "--permissions",
+        help="Load permissions",
+        action="store_true",
+        dest="load_permissions",
+        default=None,
+    )
 
     # dump sub-command.
     subparser = subparsers.add_parser("dump")
@@ -163,6 +191,27 @@ async def execute():
         yaml.dump(result, sys.stdout)
 
     elif args.which == "load":
+        # If --full is passed or not any --records, etc. specified
+        if args.full or not any(
+            (args.load_buckets, args.load_collections, args.load_records, args.load_groups)
+        ):
+            load_buckets = True
+            load_collections = True
+            load_records = True
+            load_groups = True
+        else:
+            load_buckets = args.load_buckets
+            load_collections = args.load_collections
+            load_records = args.load_records
+            load_groups = args.load_groups
+        # If --full is passed or --data and --permissions not specified
+        if args.full or (not args.load_data and not args.load_permissions):
+            load_data = True
+            load_permissions = True
+        else:
+            load_data = args.load_data
+            load_permissions = args.load_permissions
+
         logger.debug("Start initialization...")
         logger.info("Load YAML file {!r}".format(args.filepath))
         yaml = YAML(typ="safe")
@@ -176,6 +225,12 @@ async def execute():
             force=args.force,
             delete_missing_records=args.delete_records,
             attachments=args.attachments,
+            load_buckets=load_buckets,
+            load_collections=load_collections,
+            load_records=load_records,
+            load_groups=load_groups,
+            load_data=load_data,
+            load_permissions=load_permissions,
         )
 
 

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -546,3 +546,11 @@ class AttachmentsTest(FunctionalTest):
 
         record_after = self.client.get_record(bucket="main", collection="archives", id="abc")
         assert attachment_before["hash"] != record_after["data"]["attachment"]["hash"]
+
+
+class PartialLoadTest(FunctionalTest):
+    def test_load_only_groups(self):
+        self.load(filename="tests/dumps/dump-full.yaml", extra="--groups")
+
+    def test_load_only_permissions(self):
+        self.load(filename="tests/dumps/dump-full.yaml", extra="--permissions")

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -118,7 +118,7 @@ class SimpleDump(FunctionalTest):
         sys.argv = load_cmd.split(" ")
         main()
 
-        dump_cmd = cmd.format("dump", self.server, self.auth)
+        dump_cmd = cmd.format("dump", self.server, self.auth) + " --permissions"
         sys.argv = dump_cmd.split(" ")
         output = io.StringIO()
         with redirect_stdout(output):
@@ -273,7 +273,7 @@ class DataRecordsDump(FunctionalTest):
         sys.argv = load_cmd.split(" ")
         main()
 
-        cmd = "kinto-wizard {} --server={} --auth={} --data --records"
+        cmd = "kinto-wizard {} --server={} --auth={} --data --records --permissions"
         load_cmd = cmd.format("dump", self.server, self.auth)
         sys.argv = load_cmd.split(" ")
         output = io.StringIO()


### PR DESCRIPTION
**Breaking Changes**

- Unless `--full` is passed, the `dump` command won't include permissions. 

**Notes**

These options allow users to dump and load remote settings from one environment to another, without having to manually remove the `data:` and `permissions:` sections.

The flow becomes:

```
kinto-wizard dump --server https://remote-settings-dev.allizom.org/v1/  --bucket main --collection search-config --records --data --attachments binaries/ > dev-content.yaml 
```

Replace `main` by `main-worspace` in the yaml file, and:
kinto-wizard load --server https://remote-settings-dev.allizom.org/v1/  --bucket main-workspace --collection search-config --records --data --attachments binaries/ dev-content.yaml 
```

```

 